### PR TITLE
use aks-managed-poolName also for vmss match

### DIFF
--- a/exp/controllers/azuremanagedmachinepool_reconciler.go
+++ b/exp/controllers/azuremanagedmachinepool_reconciler.go
@@ -110,6 +110,11 @@ func (s *azureManagedMachinePoolService) Reconcile(ctx context.Context) error {
 			match = &ss
 			break
 		}
+
+		if ss.Tags["aks-managed-poolName"] != nil && *ss.Tags["aks-managed-poolName"] == agentPoolName {
+			match = &ss
+			break
+		}
 	}
 
 	if match == nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
port over of bugfix from upstream here:
https://github.com/kubernetes-sigs/cluster-api-provider-azure/commit/a4a800aa2ca542e4a3c4d12e8d7e1cd8248cbc5b