### PR TITLE
fix AMMP watch on machinepool mapping func passed in group version

### DIFF
--- a/exp/controllers/azuremanagedmachinepool_controller.go
+++ b/exp/controllers/azuremanagedmachinepool_controller.go
@@ -91,7 +91,7 @@ func (r *AzureManagedMachinePoolReconciler) SetupWithManager(ctx context.Context
 		// watch for changes in CAPI MachinePool resources
 		Watches(
 			&source.Kind{Type: &clusterv1exp.MachinePool{}},
-			handler.EnqueueRequestsFromMapFunc(MachinePoolToInfrastructureMapFunc(clusterv1exp.GroupVersion.WithKind("AzureManagedMachinePool"), ctrl.LoggerFrom(ctx))),
+			handler.EnqueueRequestsFromMapFunc(MachinePoolToInfrastructureMapFunc(infrav1exp.GroupVersion.WithKind("AzureManagedMachinePool"), ctrl.LoggerFrom(ctx))),
 		).
 		// watch for changes in AzureManagedControlPlanes
 		Watches(


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
details of issue here:
https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2058

**TL;DR the mapping func used by AMMP controller to watch machinepools passes in the wrong GVK (clusterv1exp instead of infrav1exp)**
